### PR TITLE
ru-check: enforce read-only contract (don't modify source files)

### DIFF
--- a/commands/ru-check.md
+++ b/commands/ru-check.md
@@ -37,6 +37,8 @@ Reference files: `${CLAUDE_PLUGIN_ROOT}/skills/ru-text/references/<filename>`
 
 ## Output format
 
+**Read-only — do NOT modify the source files.** `ru-check` is a *check*: it reports issues and returns the corrected text for the user to apply. It must not write to, edit, or overwrite the analysed file(s) — its `allowed-tools` are `Read, Grep, Glob` by design. Returning the corrected text in the output (not writing it) keeps the command deterministic and free of side effects: e.g. silently inserting NBSP into a source file that a downstream target (Notion, Telegram, Facebook) strips anyway, or that breaks later exact-string tooling (grep/replace) on that file.
+
 Return:
 1. Corrected text
 2. List of changes grouped by category (typography / style / grammar / domain)


### PR DESCRIPTION
## Problem

`ru-check` is declared read-only — `allowed-tools: Read, Grep, Glob`, and its **Output format** says *"Return: 1. Corrected text"*. So by design it reports and hands back corrected text; it is a *check*, not a fixer.

In real use this session, the forked `ru-check` run **wrote the corrected text back into the analysed file** (inserting NBSP after single-letter prepositions / before em-dashes) on some invocations, and left the file untouched on others. Same command, different behaviour — non-deterministic, and a file mutation the contract never promised.

### Why it bites

- **Invisible in the real target.** The texts were headed to Notion (and Telegram/Facebook), which **strip NBSP on paste/import** — so the inserted NBSP changes nothing the reader sees.
- **Breaks downstream tooling.** NBSP silently replaces U+0020 in the source, so later exact-string `grep`/replace on `«У кого …»`, `«в начале»`, etc. **misses** — you have to switch to NBSP-tolerant `\s+` regex to edit the very file ru-check just touched.
- **Non-deterministic.** A check that sometimes mutates and sometimes doesn't is hard to build a pipeline around.

## Change

Doc-only: make the read-only contract explicit in `commands/ru-check.md` — `ru-check` returns corrected text in its output and must not write/edit/overwrite the source file. Matches the existing `allowed-tools`. No rules touched. (If applying fixes in-place is wanted, that's better as a separate explicit `ru-fix` so `ru-check` stays a pure, deterministic check.)