### PR TITLE
docs: Code of Conduct, Security policy, PR template (GitHub Community Standards)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Thank you for contributing to better Russian text. -->
+
+## What does this PR change?
+
+<!-- One or two sentences. Link the issue it closes, if any (e.g. "Closes #42"). -->
+
+## Type
+
+- [ ] `fix:` rule correction
+- [ ] `feat:` new rule, domain, command, or platform
+- [ ] `docs:` README / documentation
+
+## Checklist
+
+- [ ] Conventional-commit title (`fix:` / `feat:` / `docs:`)
+- [ ] New rules go to `skills/ru-text/references/addenda.md` (AD-N), not domain files
+- [ ] All formulations are original — no verbatim quotes, no "distilled from", no author name as endorsement
+- [ ] Russian text follows ru-text typography (« » quotes, em/en dashes, NBSP, … glyph)
+- [ ] Reference files over 100 lines have a Table of Contents
+- [ ] If plugin behavior changed: version bumped in all manifests and `CHANGELOG.md` updated
+- [ ] `claude plugins validate .` passes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+nafigator@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Use [conventional commits](https://www.conventionalcommits.org/):
 
 ## Code of Conduct
 
-Be respectful. We're here to make Russian text better, not to argue about it.
+Be respectful. We're here to make Russian text better, not to argue about it. This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md) — please read it before participating.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+ru-text ships as a rolling latest version; security fixes land on the most recent release.
+Please upgrade to the latest version before reporting.
+
+| Version | Supported |
+|---|---|
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+## What this plugin is
+
+ru-text is a set of static Markdown files — text-quality rules, a plugin manifest, and slash
+commands defined as Markdown. It collects no data, makes no network requests, and executes no
+code (see [PRIVACY_POLICY.md](PRIVACY_POLICY.md)). The realistic security surface is therefore
+small: the main risk is a malicious or mistaken rule edit reaching users through a pull request,
+which is mitigated by review before merge.
+
+## Reporting a vulnerability
+
+Please report security issues privately — do not open a public issue.
+
+- Preferred: GitHub [private vulnerability reporting](https://github.com/talkstream/ru-text/security/advisories/new) (Security → Report a vulnerability).
+- Or email [nafigator@gmail.com](mailto:nafigator@gmail.com) with «ru-text security» in the subject.
+
+Include the affected file or rule, a description of the issue, and steps to reproduce if applicable.
+
+## What to expect
+
+This is a best-effort, single-maintainer project. You can expect an acknowledgment within a few
+days and a fix or response as soon as the issue is confirmed. Thank you for helping keep ru-text
+and its users safe.


### PR DESCRIPTION
Closes the three remaining GitHub Community Standards gaps.

## Added
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (enforcement contact: nafigator@gmail.com)
- **SECURITY.md** — supported versions, low attack surface (pure Markdown, zero data collection — cross-refs PRIVACY_POLICY.md), private vulnerability reporting
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist mirroring CONTRIBUTING conventions (conventional commits, originality, dogfood typography, version/CHANGELOG, validate)

## Changed
- **CONTRIBUTING.md** — link the Code of Conduct from its existing section

Docs only — no plugin behavior change, **no version bump** (these files are not part of the cached plugin payload).

After merge, the GitHub community profile should show Code of conduct + Security policy + Pull request template green.