### PR TITLE
docs(readme): badges + clear 'how to update' guide (RU+EN)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # ru-text
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blue?logo=anthropic)](https://github.com/anthropics/claude-plugins-community) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-30363D?logo=GitHub-Sponsors&logoColor=EA4AAA)](https://github.com/sponsors/talkstream) [![Last Updated](https://img.shields.io/github/last-commit/talkstream/ru-text/main?label=updated)](https://github.com/talkstream/ru-text)
+[![Version](https://img.shields.io/github/v/release/talkstream/ru-text?label=version&color=2ea44f)](https://github.com/talkstream/ru-text/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Platforms](https://img.shields.io/badge/platforms-12-blue)](#quick-start) [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blue?logo=anthropic)](https://github.com/anthropics/claude-plugins-community) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-30363D?logo=GitHub-Sponsors&logoColor=EA4AAA)](https://github.com/sponsors/talkstream) [![GitHub stars](https://img.shields.io/github/stars/talkstream/ru-text?style=flat&label=stars)](https://github.com/talkstream/ru-text/stargazers) [![Last commit](https://img.shields.io/github/last-commit/talkstream/ru-text/main?label=updated)](https://github.com/talkstream/ru-text)
 
 **Languages:** [Русский (primary)](README.md) | English
 
@@ -229,6 +229,41 @@ git clone https://github.com/talkstream/ru-text.git
 Then add the repo as a plugin source per your platform's docs.
 
 Start writing Russian text — the plugin takes over automatically. If ru-text makes your products better, consider [sponsoring](https://github.com/sponsors/talkstream) continued development.
+
+## Updating ru-text
+
+Latest version — **v1.10.0** (see the [CHANGELOG](CHANGELOG.md)). Check your installed version in Claude Code with `claude plugins list`.
+
+**Primary method** — for skill-based platforms (GitHub Copilot, Windsurf, Continue.dev, Cline, JetBrains Junie, Google Antigravity, manual Cursor install). Re-run the install — the command pulls the latest version from the repository and overwrites the skill:
+
+```bash
+npx skills add talkstream/ru-text
+```
+
+**Claude Code (CLI and Desktop).** Refresh the marketplace cache first, then update the plugin:
+
+```bash
+claude plugins marketplace update claude-community
+claude plugins update ru-text@claude-community
+```
+
+Restart Claude Code (or run `/reload-plugins`) to apply the change. You can also do this from the `/plugin` menu, "Installed" tab. Note: the community marketplace pins the plugin to a specific version and advances the pin automatically with up to a day's lag — if the version doesn't change right after a release, that's expected; give the marketplace time to re-pin.
+
+**Gemini CLI:**
+
+```bash
+gemini extensions update ru-text
+```
+
+**OpenClaw:**
+
+```bash
+openclaw skills update ru-text
+```
+
+**Codex CLI.** Open `/plugins`, find ru-text, and update.
+
+**Manual copy.** If you installed the skill manually (`git clone` + `cp`), repeat your platform's install steps — they overwrite the skill with the latest version.
 
 ## Domains
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ru-text
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blue?logo=anthropic)](https://github.com/anthropics/claude-plugins-community) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-30363D?logo=GitHub-Sponsors&logoColor=EA4AAA)](https://github.com/sponsors/talkstream) [![Last Updated](https://img.shields.io/github/last-commit/talkstream/ru-text/main?label=updated)](https://github.com/talkstream/ru-text)
+[![Version](https://img.shields.io/github/v/release/talkstream/ru-text?label=version&color=2ea44f)](https://github.com/talkstream/ru-text/releases/latest) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Platforms](https://img.shields.io/badge/platforms-12-blue)](#быстрый-старт) [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blue?logo=anthropic)](https://github.com/anthropics/claude-plugins-community) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-30363D?logo=GitHub-Sponsors&logoColor=EA4AAA)](https://github.com/sponsors/talkstream) [![GitHub stars](https://img.shields.io/github/stars/talkstream/ru-text?style=flat&label=stars)](https://github.com/talkstream/ru-text/stargazers) [![Last commit](https://img.shields.io/github/last-commit/talkstream/ru-text/main?label=updated)](https://github.com/talkstream/ru-text)
 
 **Языки:** Русский | [English](README.en.md)
 
@@ -231,6 +231,41 @@ git clone https://github.com/talkstream/ru-text.git
 Затем добавьте репозиторий как источник плагинов по документации вашей платформы.
 
 Начните писать на русском — плагин подключится сам. Если ru-text делает ваши продукты лучше, поддержите [разработку](https://github.com/sponsors/talkstream).
+
+## Обновление
+
+Свежая версия — **v1.10.0** (что нового — в [CHANGELOG](CHANGELOG.md)). Узнать свою версию в Claude Code: `claude plugins list`.
+
+**Основной способ** — для платформ на основе навыков (GitHub Copilot, Windsurf, Continue.dev, Cline, JetBrains Junie, Google Antigravity, ручная установка в Cursor). Повторите установку — команда подтянет последнюю версию из репозитория и перезапишет навык:
+
+```bash
+npx skills add talkstream/ru-text
+```
+
+**Claude Code (CLI и Desktop).** Сначала обновите кэш маркетплейса, затем плагин:
+
+```bash
+claude plugins marketplace update claude-community
+claude plugins update ru-text@claude-community
+```
+
+Перезапустите Claude Code (или выполните `/reload-plugins`), чтобы изменения вступили в силу. То же самое можно сделать в меню `/plugin`, вкладка «Installed». Важно: community-маркетплейс закрепляет плагин на конкретной версии и подтягивает свежую с задержкой до суток — если сразу после релиза версия не сменилась, это нормально, дайте маркетплейсу обновить закрепление.
+
+**Gemini CLI:**
+
+```bash
+gemini extensions update ru-text
+```
+
+**OpenClaw:**
+
+```bash
+openclaw skills update ru-text
+```
+
+**Codex CLI.** Откройте `/plugins`, найдите ru-text и обновите.
+
+**Ручное копирование.** Если вы устанавливали навык вручную (`git clone` + `cp`), повторите шаги установки своей платформы — они перезапишут навык свежей версией.
 
 ## Домены
 


### PR DESCRIPTION
Adds version/platform/stars badges and a dedicated **Обновление / Updating ru-text** section to both READMEs.

**Why:** ru-text was covered on Habr; new users install via the community marketplace and had no clear path to update. The version badge now shows the latest release, and the new section gives a primary method (`npx skills add talkstream/ru-text`) plus per-platform update commands, including the community-marketplace pin-lag caveat.

**Quality:** all commands fact-checked (`claude plugins …`, `gemini extensions update`, clawhub `update` engine); adversarial review to zero (fixed NBSP-before-em-dash ×6 and platforms count 13→12); RU dogfooded (NBSP, «», em dashes); RU↔EN parity verified.