### PR TITLE
docs(capability): advertise AI-text cleanup + complete Notion carve-outs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "ru-text",
   "metadata": {
-    "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence",
+    "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup",
     "version": "1.10.0"
   },
   "owner": {
@@ -14,7 +14,7 @@
       "name": "ru-text",
       "source": "./",
       "version": "1.10.0",
-      "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence",
+      "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup",
       "category": "productivity",
       "homepage": "https://github.com/talkstream/ru-text",
       "tags": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ru-text",
   "version": "1.10.0",
-  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence",
+  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence, and AI-text cleanup",
   "author": {
     "name": "Arseniy Kamyshev",
     "email": "nafigator@gmail.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ru-text",
   "version": "1.10.0",
-  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence",
+  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence, and AI-text cleanup",
   "author": {
     "name": "Arseniy Kamyshev",
     "email": "nafigator@gmail.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ru-text",
   "displayName": "ru-text",
   "version": "1.10.0",
-  "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence. Auto-activates on Russian text.",
+  "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup. Auto-activates on Russian text.",
   "author": {
     "name": "Arseniy Kamyshev",
     "email": "nafigator@gmail.com"

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: ru-text
 description: >
   Use when writing, editing, or reviewing Russian-language text, or when user
   mentions ru-text. Covers typography, info-style, editorial, UX writing, business
-  correspondence. Auto-activates on Russian text output.
+  correspondence, AI-text cleanup. Auto-activates on Russian text output.
 metadata:
   openclaw:
     always: true

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ru-text",
   "version": "1.10.0",
-  "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence"
+  "description": "Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup"
 }

--- a/notion/ru-text-notion-skill.md
+++ b/notion/ru-text-notion-skill.md
@@ -227,7 +227,7 @@ A symmetric «не X, а Y» where X was never raised — it invents an opponent
 | Дело не в модели, а в промпте. | Всё решает промпт. |
 | Это не просто инструмент, а целая экосистема. | Это экосистема: редактор, отладчик, пакетный менеджер. |
 
-Keep a genuine antithesis only when X is voiced first. Do not flag «не столько X, сколько Y» (narrowing) or a numeric correction «выросло не на 2%, а на 40%».
+Keep a genuine antithesis only when X is voiced first. Do not flag «не столько X, сколько Y» (narrowing), a numeric correction «выросло не на 2%, а на 40%», fixed idioms («не мытьём, так катаньем»), or legal formulas («не оферта, а приглашение делать оферты»).
 
 ### Непрошенная самопохвала
 
@@ -238,7 +238,7 @@ Announcing a virtue the writing should simply show — «без воды», «ч
 | Отвечу честно, без воды: дедлайн сорван. | Дедлайн сорван. |
 | Объясню чётко, по делу. | Объясню. |
 
-Allow informative «без» («кофе без сахара», «работает без интернета») and a qualifier that previews real content («Объясню коротко: значение лежит в стеке»).
+Allow informative «без» («кофе без сахара», «работает без интернета») and a qualifier that previews real content («Объясню коротко: значение лежит в стеке»). In casual or quoted speech, «честно говоря» / «прямо скажем» as natural discourse markers are fine.
 
 ### Сервисные реплики ассистента
 
@@ -249,7 +249,7 @@ Chatbot-persona flourishes — sycophantic openers and sign-offs that perform se
 | Отличный вопрос! Давайте разберёмся. | (убрать; начать с ответа) |
 | Надеюсь, это было полезно. Обращайтесь! | (убрать; закончить на сути) |
 
-Allow live dialogue, support replies, and a genuine offer in a contact block.
+Allow live dialogue, support replies, a genuine offer in a contact block, and a sincere wish in a book preface («надеюсь, книга окажется полезной»).
 
 ### Пустой зачин
 
@@ -260,7 +260,7 @@ Openers that announce explanation instead of delivering it — «давайте 
 | Давайте разберёмся, как это работает. | Алгоритм делает три вещи: … |
 | Важно понимать, что скорость зависит от железа. | Скорость зависит от железа. |
 
-Allow a real summative «итак», a genuine tutorial step, and an informative «важно … — от этого зависит …».
+Allow a real summative «итак», a genuine tutorial step, an informative «важно … — от этого зависит …», and «давайте разберёмся» in live or quoted dialogue.
 
 ## Quality Checklist
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "ru-text",
   "name": "ru-text",
   "version": "1.10.0",
-  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence",
+  "description": "Russian text quality plugin — typography, information style, editorial standards, UX writing, business correspondence, and AI-text cleanup",
   "configSchema": {
     "type": "object",
     "additionalProperties": false

--- a/skills/ru-text/SKILL.md
+++ b/skills/ru-text/SKILL.md
@@ -3,7 +3,7 @@ name: ru-text
 description: >
   Use when writing, editing, or reviewing Russian-language text, or when user
   mentions ru-text. Covers typography, info-style, editorial, UX writing, business
-  correspondence. Auto-activates on Russian text output.
+  correspondence, AI-text cleanup. Auto-activates on Russian text output.
 metadata:
   openclaw:
     always: true

--- a/skills/ru-text/agents/gemini.yaml
+++ b/skills/ru-text/agents/gemini.yaml
@@ -1,3 +1,3 @@
 interface:
   display_name: "ru-text"
-  short_description: "Russian text quality — typography, info-style, editorial, UX writing, business correspondence"
+  short_description: "Russian text quality — typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup"

--- a/skills/ru-text/agents/openai.yaml
+++ b/skills/ru-text/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "ru-text"
-  short_description: "Russian text quality — typography, info-style, editorial, UX writing, business correspondence"
+  short_description: "Russian text quality — typography, info-style, editorial, UX writing, business correspondence, and AI-text cleanup"
 
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
Comprehensive capability-parity pass so the v1.10.0 neuroslop capability is reflected on **every** surface we offer.

- **Descriptions** (8 manifest/metadata files + the cross-platform `SKILL.md` descriptor and its root mirror): the capability list now ends '…business correspondence, **and AI-text cleanup**'. All valid JSON/YAML, ≤250 chars, SKILL.md mirror kept identical.
- **Notion AI-Skill template**: the condensed neuroslop section now carries the full carve-out set (fixed idioms + legal formulas for antithesis, conversational «честно говоря», book-preface wish, dialogue-register «давайте разберёмся»), matching the canonical AD-6/7/8/9.

No version bump — these are listing/descriptor changes that propagate to marketplaces via the normal HEAD-pin sync. Code review to 0 issues (faithfulness, JSON/YAML validity, char limits, dogfood, scope).